### PR TITLE
Standardize rendering priorities

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -128,8 +128,8 @@ a:hover { color: black; text-decoration: none; background-color: #D1D1D1; }
 
 .result h1 { margin-bottom: 0.5em; }
 
-ul.custom { list-style: none; padding-left: 20px; }
-ul.custom > li:before { content: attr(data-content) '.'; padding-right: 7px; }
+ul.srn-priorities { list-style: none; padding-left: 20px; }
+ul.srn-priorities > li:before { content: attr(srn-priority) '.'; padding-right: 7px; }
 
 .editor { width: 100%; height: 100px; }
 .execute { font-size: 1.5em; padding-left: 3em; padding-right: 3em; }

--- a/js/script.js
+++ b/js/script.js
@@ -169,7 +169,7 @@ var formatSyntax = (function () {
                     attr = '';
                     
                 if (item.priority) {
-                    attr = ' data-content="' + item.priority + '"';
+                    attr = ' srn-priority="' + item.priority + '"';
                     hasPriorities = true;
                 }
                 result += '<li' + attr + '>';
@@ -186,7 +186,7 @@ var formatSyntax = (function () {
                 result += '</li>';
             }
 
-            result =  '<ul' + (hasPriorities ? ' class="custom"' : '') + '>' + result + '</ul>';
+            result =  '<ul' + (hasPriorities ? ' class="srn-priorities"' : '') + '>' + result + '</ul>';
                     
             return result;
         },


### PR DESCRIPTION
In order to not conflict with another css framework or other, and to standardize all Semantic Release Notes HTML rendering.
Replace `custom` class by `srn-priorities` and `data-content` by `srn-priority`