### PR TITLE
Support metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,7 +317,7 @@ This is the summary for Other Section.
                         <div class="result"></div>
                         <pre class="object"></pre>
                     </div> 
-            
+
                     <h3>Metadata</h3>
                     <p>
                         It can be useful to add some metadata to a release note, for example the list of commits targeted by the release note.
@@ -325,18 +325,27 @@ This is the summary for Other Section.
                     <p>
                         All metadata can be preceded by its name (case insensitive) followed by a colon, but each supported metadata have it's own syntax:
                         <ul>
-                            <li>Commits: the first and last commits separated by three dots, included or not in a link
+                            <li>Commits: the first and last commits separated by three dots, included or not in a link. Name optional.</li>
+                            <li>Contributors: list of all contributors for the release. Name mandatory.</li>
+                            <li>Source: link to the sources. Name mandatory.</li>
+                            <li>Binaries: link to the binaries. Name mandatory.</li>
+                            <li>Generated at: generation time of the release notes with the following format: yyyy-mm-ddTHH:mm:ssZ (ISO 8601). Name optional.</li>
                         </ul>
                     </p>
                     <div class="container">
                         <strong>Examples:</strong>
                         <pre class="code">56af25a...d3fead4
 Commits: [56af25a...d3fead4](https://github.com/Glimpse/Semantic-Release-Notes/compare/56af25a...d3fead4)
+Contributors: Jérémie Bertrand, Jake Ginnivan, [Anthony van der Hoorn](https://github.com/avanderhoorn)
+source: [MyPackage.zip](https://github.com/laedit/MyPackage/archive/v0.1.0.zip)
+binaries: [MyPackage.exe](https://github.com/laedit/MyPackage/releases/download/v0.1.0/MyPackage.exe)
+Generated at: 2015-05-04T08:45:36Z
+2015-05-04T08:45:36Z
                         </pre>
                         <div class="result"></div>
                         <pre class="object"></pre>
-                    </div> 
-            
+                    </div>
+
                     <h3>Release (Not Working)</h3>
                     <p>
                         In some cases we want to have the one document that describes many releases. In this case, the 
@@ -550,7 +559,7 @@ Commits: [56af25a...d3fead4](https://github.com/Glimpse/Semantic-Release-Notes/c
 
 
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
-    <script>window.jQuery || document.write('<script src="js/libs/jquery-1.7.1.min.js"><\/script>')</script> 
+    <script>window.jQuery || document.write('<script src="js/libs/jquery-1.7.1.min.js"><\/script>');</script> 
     <script src="js/script.js"></script> 
 <script type="text/javascript">
   var _gaq = _gaq || [];

--- a/index.html
+++ b/index.html
@@ -323,14 +323,14 @@ This is the summary for Other Section.
                         It can be useful to add some metadata to a release note, for example the list of commits targeted by the release note.
                     </p>
                     <p>
-                        Each supported metadata have it's own syntax, here is the list:
+                        All metadata can be preceded by its name (case insensitive) followed by a colon, but each supported metadata have it's own syntax:
                         <ul>
-                            <li>Commits: the word "commits" (case insensitive) followed by a colon, then the first and last commits separated by three dots, included or not in a link
+                            <li>Commits: the first and last commits separated by three dots, included or not in a link
                         </ul>
                     </p>
                     <div class="container">
                         <strong>Examples:</strong>
-                        <pre class="code">commits:56af25a...d3fead4
+                        <pre class="code">56af25a...d3fead4
 Commits: [56af25a...d3fead4](https://github.com/Glimpse/Semantic-Release-Notes/compare/56af25a...d3fead4)
                         </pre>
                         <div class="result"></div>

--- a/index.html
+++ b/index.html
@@ -193,6 +193,10 @@
                                 "+New", "+Change", "+Bug-Fix", +Developer". This is indicated via a single word, or - (dash) delimited phrase, that has a "+" prefix. 
                             </li>
                             <li>
+                                <strong>Metadata</strong>:
+                                A list of metadata can be added to a release note. Only some elements are possible, with their respective specific syntax.
+                            </li>
+                            <li>
                                 <strong>Release</strong>:
                                 As SRN allows for many releases to be defined within the one block of text, the system needs 
                                 to provide a means by which an individual release can be identified.
@@ -314,6 +318,25 @@ This is the summary for Other Section.
                         <pre class="object"></pre>
                     </div> 
             
+                    <h3>Metadata</h3>
+                    <p>
+                        It can be useful to add some metadata to a release note, for example the list of commits targeted by the release note.
+                    </p>
+                    <p>
+                        Each supported metadata have it's own syntax, here is the list:
+                        <ul>
+                            <li>Commits: the word "commits" (case insensitive) followed by a colon, then the first and last commits separated by three dots, included or not in a link
+                        </ul>
+                    </p>
+                    <div class="container">
+                        <strong>Examples:</strong>
+                        <pre class="code">commits:56af25a...d3fead4
+Commits: [56af25a...d3fead4](https://github.com/Glimpse/Semantic-Release-Notes/compare/56af25a...d3fead4)
+                        </pre>
+                        <div class="result"></div>
+                        <pre class="object"></pre>
+                    </div> 
+            
                     <h3>Release (Not Working)</h3>
                     <p>
                         In some cases we want to have the one document that describes many releases. In this case, the 
@@ -378,7 +401,7 @@ This is the summary for Other Section for 2.0.
             <div>
                 <input name="menu-root-radio" class="menu-root-radio" id="Examples" type="radio" />
                 <div class="section-syntax"> 
-                    <a id="Exmaples"></a>
+                    <a id="Examples"></a>
                     <h2>Examples</h2>
                     <div class="section-editor">
                         <ul class="tabs">
@@ -455,7 +478,9 @@ This description is specific to system section.
 # Plugin [[icon][http://getglimpse.com/release/icon/mvc.png]]
 This description is specific to plugin section.
  1. *Timeline*: Comes with an additional grid view to show the same data. +Changed
- 1. *Ajax*: Fix that crashed poll in Chrome and IE due to log/trace statement. +Fix [[i1234][http://getglimpse.com]]</pre>
+ 1. *Ajax*: Fix that crashed poll in Chrome and IE due to log/trace statement. +Fix [[i1234][http://getglimpse.com]]
+
+Commits: [56af25a...d3fead4](https://github.com/Glimpse/Semantic-Release-Notes/compare/56af25a...d3fead4)</pre>
                                 <strong>Result:</strong>
                                 <div class="result"></div>
                                 <strong>Object:</strong>
@@ -518,7 +543,7 @@ This description is specific to plugin section.
         </section>  
         <footer>
             <div class="footer-inner">
-                Copyright &copy; 2013<br /> Anthony van der Hoorn &amp; Nik Molnar
+                Copyright &copy; 2015<br /> Anthony van der Hoorn &amp; Nik Molnar
             </div>
         </footer>
     </div>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <!--[if lt IE 7]><p class=chromeframe>Your browser is <em>ancient!</em> <a href="http://browsehappy.com/">Upgrade to a different browser</a> or <a href="http://www.google.com/chromeframe/?redirect=true">install Google Chrome Frame</a> to experience this site.</p><![endif]-->
     <div class="wrapper"> 
         <section class="box box-top">
-            <h1>Semantic Release Notes <span class="light">v 0.3</span></h1> 
+            <h1>Semantic Release Notes <span class="light">v 0.4-beta</span></h1> 
         </section>
         <header>
             <div class="header-inner">
@@ -192,6 +192,10 @@
                                 "+New", "+Change", "+Bug-Fix", +Developer". This is indicated via a single word, or - (dash) delimited phrase, that has a "+" prefix. 
                             </li>
                             <li>
+                                <strong>Metadata</strong>:
+                                A list of metadata can be added to a release note. Only some elements are possible, with their respective specific syntax.
+                            </li>
+                            <li>
                                 <strong>Release</strong>:
                                 As SRN allows for many releases to be defined within the one block of text, the system needs 
                                 to provide a means by which an individual release can be identified.
@@ -312,6 +316,25 @@ This is the summary for Other Section.
                         <pre class="object"></pre>
                     </div> 
             
+                    <h3>Metadata</h3>
+                    <p>
+                        It can be useful to add some metadata to a release note, for example the list of commits targeted by the release note.
+                    </p>
+                    <p>
+                        Each supported metadata have it's own syntax, here is the list:
+                        <ul>
+                            <li>Commits: the word "commits" (case insensitive) followed by a colon, then the first and last commits separated by three dots, included or not in a link
+                        </ul>
+                    </p>
+                    <div class="container">
+                        <strong>Examples:</strong>
+                        <pre class="code">commits:56af25a...d3fead4
+Commits: [56af25a...d3fead4](https://github.com/Glimpse/Semantic-Release-Notes/compare/56af25a...d3fead4)
+                        </pre>
+                        <div class="result"></div>
+                        <pre class="object"></pre>
+                    </div> 
+            
                     <h3>Release (Not Working)</h3>
                     <p>
                         In some cases we want to have the one document that describes many releases. In this case, the 
@@ -376,7 +399,7 @@ This is the summary for Other Section for 2.0.
             <div>
                 <input name="menu-root-radio" class="menu-root-radio" id="Examples" type="radio" />
                 <div class="section-syntax"> 
-                    <a id="Exmaples"></a>
+                    <a id="Examples"></a>
                     <h2>Examples</h2>
                     <div class="section-editor">
                         <ul class="tabs">
@@ -453,7 +476,9 @@ This description is specific to system section.
 # Plugin [[icon][http://getglimpse.com/release/icon/mvc.png]]
 This description is specific to plugin section.
  1. *Timeline*: Comes with an additional grid view to show the same data. +Changed
- 1. *Ajax*: Fix that crashed poll in Chrome and IE due to log/trace statement. +Fix [[i1234][http://getglimpse.com]]</pre>
+ 1. *Ajax*: Fix that crashed poll in Chrome and IE due to log/trace statement. +Fix [[i1234][http://getglimpse.com]]
+
+Commits: [56af25a...d3fead4](https://github.com/Glimpse/Semantic-Release-Notes/compare/56af25a...d3fead4)</pre>
                                 <strong>Result:</strong>
                                 <div class="result"></div>
                                 <strong>Object:</strong>
@@ -501,7 +526,7 @@ This description is specific to plugin section.
         </section>  
         <footer>
             <div class="footer-inner">
-                Copyright &copy; 2013<br /> Anthony van der Hoorn &amp; Nik Molnar
+                Copyright &copy; 2015<br /> Anthony van der Hoorn &amp; Nik Molnar
             </div>
         </footer>
     </div>

--- a/index.html
+++ b/index.html
@@ -321,14 +321,14 @@ This is the summary for Other Section.
                         It can be useful to add some metadata to a release note, for example the list of commits targeted by the release note.
                     </p>
                     <p>
-                        Each supported metadata have it's own syntax, here is the list:
+                        All metadata can be preceded by its name (case insensitive) followed by a colon, but each supported metadata have it's own syntax:
                         <ul>
-                            <li>Commits: the word "commits" (case insensitive) followed by a colon, then the first and last commits separated by three dots, included or not in a link
+                            <li>Commits: the first and last commits separated by three dots, included or not in a link
                         </ul>
                     </p>
                     <div class="container">
                         <strong>Examples:</strong>
-                        <pre class="code">commits:56af25a...d3fead4
+                        <pre class="code">56af25a...d3fead4
 Commits: [56af25a...d3fead4](https://github.com/Glimpse/Semantic-Release-Notes/compare/56af25a...d3fead4)
                         </pre>
                         <div class="result"></div>

--- a/js/script.js
+++ b/js/script.js
@@ -105,6 +105,28 @@ var processSyntax = (function () {
                     else 
                         obj.sections[obj.sections.length - 1].items.push(item); 
                 }
+            },
+            {
+                metadataPatterns : [{ name : 'Commits', pattern : /^(?:commits:)?[ ]*(?:([0-9a-f]{5,40}\.{3}[0-9a-f]{5,40})|(\[[0-9a-f]{5,40}\.{3}[0-9a-f]{5,40}\]\(https?:\/\/\S+\)))$/i }],
+                test : function (input) {
+                    return this.metadataPatterns.some(function (element, index, array)
+                    {
+                        return element.pattern.test(input)
+                    });
+                },
+                process : function (obj, input) {
+                
+                    for(var metadataPatternIndex in this.metadataPatterns) {
+                        var metadataPattern = this.metadataPatterns[metadataPatternIndex];
+                        var metadata = metadataPattern.pattern.exec(input);
+                        if (metadata) {
+                            if (!obj.metadata) {
+                                obj.metadata = [];
+                            }
+                            obj.metadata.push({ name : metadataPattern.name, data : metadata[1] ? metadata[1] : metadata[2] });
+                        }
+                    }
+                }
             }],
             primary : {
                 pattern : /^[a-zA-Z0-9]/i,
@@ -237,7 +259,13 @@ var formatSyntax = (function () {
                 
                 result += '<div><h1>' + feature.name + '</h1>' + processString(feature.summary) + processList(feature.items) + '</div>';
             }
-
+			
+			for (var metadataIndex in val.metadata) {
+				var metadata = val.metadata[metadataIndex];
+				
+				result += '<div>' + metadata.name + ': ' + processString(metadata.data) + '</div>';
+			}
+			
             return result; 
         };
             

--- a/js/script.js
+++ b/js/script.js
@@ -75,6 +75,28 @@ var processSyntax = (function () {
                     else 
                         obj.sections[obj.sections.length - 1].items.push(item); 
                 }
+            },
+            {
+                metadataPatterns : [{ name : 'Commits', pattern : /^(?:commits:)?[ ]*(?:([0-9a-f]{5,40}\.{3}[0-9a-f]{5,40})|(\[[0-9a-f]{5,40}\.{3}[0-9a-f]{5,40}\]\(https?:\/\/\S+\)))$/i }],
+                test : function (input) {
+                    return this.metadataPatterns.some(function (element, index, array)
+                    {
+                        return element.pattern.test(input)
+                    });
+                },
+                process : function (obj, input) {
+                
+                    for(var metadataPatternIndex in this.metadataPatterns) {
+                        var metadataPattern = this.metadataPatterns[metadataPatternIndex];
+                        var metadata = metadataPattern.pattern.exec(input);
+                        if (metadata) {
+                            if (!obj.metadata) {
+                                obj.metadata = [];
+                            }
+                            obj.metadata.push({ name : metadataPattern.name, data : metadata[1] ? metadata[1] : metadata[2] });
+                        }
+                    }
+                }
             }],
             primary : {
                 pattern : /^[a-zA-Z0-9]/i,
@@ -114,7 +136,7 @@ var processSyntax = (function () {
                 if (!matched)
                     lineProcessor.primary.process(result, rawLine, rawLines[+rawLineIndex + 1]);
             }
-                    
+            
             return result;
         };
              
@@ -199,7 +221,13 @@ var formatSyntax = (function () {
                 
                 result += '<div><h1>' + feature.name + '</h1>' + processString(feature.summary) + processList(feature.items) + '</div>';
             }
-
+			
+			for (var metadataIndex in val.metadata) {
+				var metadata = val.metadata[metadataIndex];
+				
+				result += '<div>' + metadata.name + ': ' + processString(metadata.data) + '</div>';
+			}
+			
             return result; 
         };
             

--- a/js/script.js
+++ b/js/script.js
@@ -77,23 +77,27 @@ var processSyntax = (function () {
                 }
             },
             {
-                metadataPatterns : [{ name : 'Commits', pattern : /^(?:commits:)?[ ]*(?:([0-9a-f]{5,40}\.{3}[0-9a-f]{5,40})|(\[[0-9a-f]{5,40}\.{3}[0-9a-f]{5,40}\]\(https?:\/\/\S+\)))$/i }],
+                metadataCollection : [{ 
+                        name : 'Commits', 
+                        pattern : /^(?:commits:)?[ ]*(?:([0-9a-f]{5,40}\.{3}[0-9a-f]{5,40})|(\[[0-9a-f]{5,40}\.{3}[0-9a-f]{5,40}\]\(https?:\/\/\S+\)))$/i,
+                        getValue : function(metadataMatch) { return metadataMatch[1] ? metadataMatch[1] : metadataMatch[2] }
+                    }],
                 test : function (input) {
-                    return this.metadataPatterns.some(function (element, index, array)
+                    return this.metadataCollection.some(function (element, index, array)
                     {
                         return element.pattern.test(input)
                     });
                 },
                 process : function (obj, input) {
                 
-                    for(var metadataPatternIndex in this.metadataPatterns) {
-                        var metadataPattern = this.metadataPatterns[metadataPatternIndex];
-                        var metadata = metadataPattern.pattern.exec(input);
-                        if (metadata) {
+                    for(var metadataIndex in this.metadataCollection) {
+                        var metadata = this.metadataCollection[metadataIndex];
+                        var metadataMatch = metadata.pattern.exec(input);
+                        if (metadataMatch) {
                             if (!obj.metadata) {
                                 obj.metadata = [];
                             }
-                            obj.metadata.push({ name : metadataPattern.name, data : metadata[1] ? metadata[1] : metadata[2] });
+                            obj.metadata.push({ name : metadata.name, data : metadata.getValue(metadataMatch) });
                         }
                     }
                 }

--- a/js/script.js
+++ b/js/script.js
@@ -107,23 +107,27 @@ var processSyntax = (function () {
                 }
             },
             {
-                metadataPatterns : [{ name : 'Commits', pattern : /^(?:commits:)?[ ]*(?:([0-9a-f]{5,40}\.{3}[0-9a-f]{5,40})|(\[[0-9a-f]{5,40}\.{3}[0-9a-f]{5,40}\]\(https?:\/\/\S+\)))$/i }],
+                metadataCollection : [{ 
+                        name : 'Commits', 
+                        pattern : /^(?:commits:)?[ ]*(?:([0-9a-f]{5,40}\.{3}[0-9a-f]{5,40})|(\[[0-9a-f]{5,40}\.{3}[0-9a-f]{5,40}\]\(https?:\/\/\S+\)))$/i,
+                        getValue : function(metadataMatch) { return metadataMatch[1] ? metadataMatch[1] : metadataMatch[2] }
+                    }],
                 test : function (input) {
-                    return this.metadataPatterns.some(function (element, index, array)
+                    return this.metadataCollection.some(function (element, index, array)
                     {
                         return element.pattern.test(input)
                     });
                 },
                 process : function (obj, input) {
                 
-                    for(var metadataPatternIndex in this.metadataPatterns) {
-                        var metadataPattern = this.metadataPatterns[metadataPatternIndex];
-                        var metadata = metadataPattern.pattern.exec(input);
-                        if (metadata) {
+                    for(var metadataIndex in this.metadataCollection) {
+                        var metadata = this.metadataCollection[metadataIndex];
+                        var metadataMatch = metadata.pattern.exec(input);
+                        if (metadataMatch) {
                             if (!obj.metadata) {
                                 obj.metadata = [];
                             }
-                            obj.metadata.push({ name : metadataPattern.name, data : metadata[1] ? metadata[1] : metadata[2] });
+                            obj.metadata.push({ name : metadata.name, data : metadata.getValue(metadataMatch) });
                         }
                     }
                 }


### PR DESCRIPTION
Proposal for the support of metadata and specifically commits (Fix #14).

All metadata can be preceded by its name (case insensitive) followed by a colon, but each supported metadata have it's own syntax.

**Example**
For commits it's the first and last commits of the release separated by three dots and can be included in a link.

Input:
- `56af25a...d3fead4`
- `Commits: [56af25a...d3fead4](https://github.com/Glimpse/Semantic-Release-Notes/compare/56af25a...d3fead4)`

Result:

```
{
    "metadata" : [ {
            "name" : "Commits",
            "data" : "56af25a...d3fead4"
        }, {
            "name" : "Commits",
            "data" : "[56af25a...d3fead4](https://github.com/Glimpse/Semantic-Release-Notes/compare/56af25a...d3fead4)"
        } ],
    "summary" : ""
}
```

Html:

> Commits: 56af25a...d3fead4
> Commits: [56af25a...d3fead4](https://github.com/Glimpse/Semantic-Release-Notes/compare/56af25a...d3fead4)
